### PR TITLE
Misc compiler fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,9 @@ LIST(APPEND libkvtree_install_headers
 	kvtree.h
     kvtree_util.h
 )
-IF(MPI)
+IF(MPI_FOUND)
     LIST(APPEND libkvtree_install_headers kvtree_mpi.h)
-ENDIF(MPI)
+ENDIF(MPI_FOUND)
 INSTALL(FILES ${libkvtree_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 LIST(APPEND libkvtree_srcs
@@ -24,9 +24,9 @@ LIST(APPEND libkvtree_srcs
     tv_data_display.c
 )
 
-IF(MPI)
+IF(MPI_FOUND)
 	LIST(APPEND libkvtree_srcs kvtree_mpi.c kvtree_mpi_io.c)
-ENDIF(MPI)
+ENDIF(MPI_FOUND)
 
 # KVTREE Library
 ADD_LIBRARY(kvtree_o OBJECT ${libkvtree_srcs})

--- a/src/kvtree.c
+++ b/src/kvtree.c
@@ -8,6 +8,7 @@
 #include "kvtree.h"
 #include "kvtree_io.h"
 #include "kvtree_helpers.h"
+#include "kvtree_util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1770,7 +1771,7 @@ int kvtree_log(const kvtree* hash, int log_level, int indent)
   return KVTREE_SUCCESS;
 }
 
-#ifndef HIDE_TV
+#ifdef HAVE_TV
 /*
 =========================================
 Pretty print for TotalView debug window


### PR DESCRIPTION
Fix some GCC -Wall errors:
```
kvtree.c:1660:5: warning: implicit declaration of function ‘kvtree_util_set_str’
kvtree.c:1661:5: warning: implicit declaration of function ‘kvtree_util_set_bytecount’
kvtree.c:1786:12: warning: ‘TV_ttf_display_type’ defined but not used
```
Also fix this error when building without MPI:
```
kvtree_mpi.h:4:10: fatal error: mpi.h: No such file or directory
```