### PR TITLE
Misc build fixes and header cleanups

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,23 +23,24 @@ ADD_TEST(roundtrip_tests test_kvtree)
 # print test script
 FIND_PROGRAM(PRINT_TEST ${CMAKE_CURRENT_SOURCE_DIR}/print_test)
 ADD_TEST(NAME print_test COMMAND ${PRINT_TEST} ${PROJECT_BINARY_DIR}/src/kvtree_print_file ${CMAKE_CURRENT_SOURCE_DIR}/files)
-#ADD_TEST(NAME kvtree_bcast COMMAND "mpirun -np 2 ./kvtree_bcast_test)
+
+IF(MPI_FOUND)
 ADD_EXECUTABLE(kvtree_bcast_test test_kvtree_bcast.c)
 TARGET_LINK_LIBRARIES(kvtree_bcast_test ${KVTREE_EXTERNAL_LIBS} kvtree)
-#ADD_TEST(NAME kvtree_bcast_test COMMAND ${MPIEXEC} -n 3 ./kvtree_bcast_test)
 ADD_TEST(NAME kvtree_bcast_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 3 ./kvtree_bcast_test)
+
 ADD_EXECUTABLE(kvtree_send_recv_test test_kvtree_send_recv.c)
 TARGET_LINK_LIBRARIES(kvtree_send_recv_test ${KVTREE_EXTERNAL_LIBS} kvtree)
-#ADD_TEST(NAME kvtree_send_recv_test COMMAND ${MPIEXEC} -n 3 ./kvtree_send_recv_test)
 ADD_TEST(NAME kvtree_send_recv_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 3 ./kvtree_send_recv_test)
+
 ADD_EXECUTABLE(kvtree_exchange_test test_kvtree_exchange.c)
 TARGET_LINK_LIBRARIES(kvtree_exchange_test ${KVTREE_EXTERNAL_LIBS} kvtree)
-#ADD_TEST(NAME kvtree_exchange_test COMMAND ${MPIEXEC} -n 3 ./kvtree_exchange_test)
 ADD_TEST(NAME kvtree_exchange_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 3 ./kvtree_exchange_test)
+
 ADD_EXECUTABLE(kvtree_write_gather_test test_kvtree_write_gather.c)
 TARGET_LINK_LIBRARIES(kvtree_write_gather_test ${KVTREE_EXTERNAL_LIBS} kvtree)
-#ADD_TEST(NAME kvtree_write_gather_test COMMAND ${MPIEXEC} -n 3 ./kvtree_write_gather_test
 ADD_TEST(NAME kvtree_write_gather_test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 3 ./kvtree_write_gather_test)
+ENDIF(MPI_FOUND)
 
 
 ####################

--- a/test/test_kvtree.c
+++ b/test/test_kvtree.c
@@ -3,9 +3,9 @@
 #include "test_kvtree_kv.h"
 #include "test_kvtree_util.h"
 
-#include "stdlib.h"
-#include "stdio.h"
-#include "string.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 void register_test(test_ptr_t test, char* test_name){
   char* name = strdup(test_name);

--- a/test/test_kvtree_exchange.c
+++ b/test/test_kvtree_exchange.c
@@ -1,7 +1,7 @@
 #include "test_kvtree.h"
 #include "test_kvtree_util.h"
-#include "mpi.h"
-#include "stdio.h"
+#include "kvtree_mpi.h"
+#include <stdio.h>
 
 
 int main(int argc, char** argv){

--- a/test/test_kvtree_send_recv.c
+++ b/test/test_kvtree_send_recv.c
@@ -2,7 +2,7 @@
 #include "test_kvtree_util.h"
 #include "kvtree_mpi.h"
 #include "mpi.h"
-#include "stdio.h"
+#include <stdio.h>
 
 
 int main(int argc, char** argv){

--- a/test/test_kvtree_write_gather.c
+++ b/test/test_kvtree_write_gather.c
@@ -1,7 +1,7 @@
 #include "test_kvtree.h"
 #include "test_kvtree_util.h"
-#include "mpi.h"
-#include "stdio.h"
+#include "kvtree_mpi.h"
+#include <stdio.h>
 
 
 int main(int argc, char** argv){


### PR DESCRIPTION
- Add headers to fix:
```
test_kvtree_write_gather.c: warning: implicit declaration of function ‘kvtree_write_gather’
test_kvtree_exchange.c: warning: implicit declaration of function ‘kvtree_exchange_sendq
```
- Only build MPI tests when MPI is present.  Fixes:
```
test_kvtree_write_gather.c mpi.h: No such file or directory
```
- Use brackets instead of quotes when including system headers

Fixes: #27