### PR TITLE
Fix build error on Fedora 32 w/gcc 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
-langauge: c
 dist: trusty
-
-compiler:
-  - gcc
-  - clang
 
 matrix:
   include:

--- a/test/test_kvtree.c
+++ b/test/test_kvtree.c
@@ -7,6 +7,10 @@
 #include <stdio.h>
 #include <string.h>
 
+int num_tests;
+test_ptr_t* test_ptrs;
+char** test_names;
+
 void register_test(test_ptr_t test, char* test_name){
   char* name = strdup(test_name);
   test_ptrs[num_tests] = test;

--- a/test/test_kvtree.h
+++ b/test/test_kvtree.h
@@ -15,10 +15,6 @@
 
 typedef int (*test_ptr_t)( void );
 
-int num_tests;
-test_ptr_t* test_ptrs;
-char** test_names;
-
 void register_test(test_ptr_t test, char* test_name);
 
 #endif //TEST_KVTREE_H


### PR DESCRIPTION
This fixes a "multiple decleration" build error on GCC 10.

Fixes: #34