### PR TITLE
Add file locking, make kvtree_setf() thread safe

### DIFF
--- a/src/kvtree.h
+++ b/src/kvtree.h
@@ -257,7 +257,12 @@ int kvtree_read_file(const char* file, kvtree* hash);
 /** given a filename and hash, lock/open/read/close/unlock the file storing its contents in the hash */
 int kvtree_read_with_lock(const char* file, kvtree* hash);
 
-/** given a filename and hash, lock the file, open it, and read it into hash, set fd to the opened file descriptor */
+/** given a filename and hash, lock/open/read/close/unlock the file storing its contents in the hash */
+int kvtree_write_with_lock(const char* file, kvtree* hash);
+
+/** given a filename and hash, lock the file, open it, and read it into hash, set fd to the opened file descriptor.
+ * Note that this function actually acquires a write lock, not a read lock, allowing you do a read-modify-write
+ * before you unlock it.  */
 int kvtree_lock_open_read(const char* file, int* fd, kvtree* hash);
 
 /** given a filename, an opened file descriptor, and a hash, overwrite file with hash, close, and unlock file */

--- a/src/kvtree_io.h
+++ b/src/kvtree_io.h
@@ -67,8 +67,9 @@ int kvtree_close(const char* file, int fd);
 int kvtree_file_lock_write(const char* file, int fd);
 int kvtree_file_unlock(const char* file, int fd);
 
-/** opens specified file and waits on for an exclusive lock before returning the file descriptor */
-int kvtree_open_with_lock(const char* file, int flags, mode_t mode);
+/** opens specified file and waits for a shared lock if write=0 or an exclusive
+ *  lock if write=1 before returning the file descriptor */
+int kvtree_open_with_lock(const char* file, int flags, mode_t mode, int write);
 
 /** unlocks the specified file descriptor and then closes the file */
 int kvtree_close_with_unlock(const char* file, int fd);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,11 @@ ADD_TEST(roundtrip_tests test_kvtree)
 FIND_PROGRAM(PRINT_TEST ${CMAKE_CURRENT_SOURCE_DIR}/print_test)
 ADD_TEST(NAME print_test COMMAND ${PRINT_TEST} ${PROJECT_BINARY_DIR}/src/kvtree_print ${CMAKE_CURRENT_SOURCE_DIR}/files)
 
+# Test multiple processes writing to the same file at the same time
+ADD_EXECUTABLE(test_kvtree_write_locking test_kvtree_write_locking.c)
+TARGET_LINK_LIBRARIES(test_kvtree_write_locking ${KVTREE_EXTERNAL_LIBS} kvtree)
+ADD_TEST(NAME test_kvtree_write_locking COMMAND test_kvtree_write_locking)
+
 IF(MPI_FOUND)
 
 ADD_EXECUTABLE(kvtree_bcast_test test_kvtree_bcast.c)

--- a/test/test_kvtree_write_locking.c
+++ b/test/test_kvtree_write_locking.c
@@ -1,0 +1,131 @@
+/*
+ * This test spawns off a bunch of processes that all try to read and write the
+ * same kvtree file over and over.  It is actually two tests - first, it tests
+ * that there is file corruption if the kvtree file is written with no locking.
+ * Second, it verifies that there is no corruption if locking is used.
+ */
+
+#include "kvtree.h"
+#include "test_kvtree_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/sysinfo.h>
+
+#define PROCESSES 8
+#define ITERATIONS 1000
+#define TESTFILE "/dev/shm/test_kvtree_write_locking"
+
+/*
+ * This is our process function that writes the file and then tries to read it.
+ * Return NULL on success, non-NULL otherwise.
+ */
+int process_func(int use_locking)
+{
+  kvtree *kvtree;
+  int rc;
+  int iterations = ITERATIONS;
+
+  srand(1);
+
+  while (iterations--) {
+    kvtree = kvtree_new();
+
+    kvtree_util_set_int64(kvtree, "DATA",  rand());
+
+    if (use_locking) {
+      rc = kvtree_write_with_lock(TESTFILE, kvtree);
+    } else {
+      rc = kvtree_write_file(TESTFILE, kvtree);
+    }
+    kvtree_delete(&kvtree);
+
+    if (rc != KVTREE_SUCCESS) {
+      /* Couldn't write file */
+      return 1;
+    }
+
+    kvtree = kvtree_new();
+    if ((kvtree_read_with_lock(TESTFILE, kvtree) != KVTREE_SUCCESS)) {
+      /* Couldn't read file */
+      kvtree_delete(&kvtree);
+      return 1;
+    }
+    kvtree_delete(&kvtree);
+  }
+
+  return 0;    /* success */
+}
+
+/*
+ * Spawn off a bunch of processes th
+ */
+int spawn_processes(int use_locking)
+{
+  int rc;
+  int i;
+  pid_t pids[PROCESSES] = {0};
+  int status;
+  pid_t child_pid;
+  int failures = 0;
+
+  /* Wait for the threads to finish */
+  for (i = 0; i < PROCESSES; i++) {
+    child_pid = fork();
+    if (child_pid == 0) {
+      /* We're a child. */
+      process_func(use_locking);
+
+      /* Try to write our kvtree and pass our return code to exit() */
+      rc = process_func(use_locking);
+      exit(rc);
+      break;
+    } else {
+      pids[i] = child_pid;
+      /* We're the original process (parent).  Keep spawning children */
+    }
+  }
+
+  for (i = 0; i < PROCESSES; i++) {
+    waitpid(pids[i], &status, 0);
+    status = WEXITSTATUS(status);
+    if (status != 0) {
+      failures++;
+    }
+  }
+  return failures;
+}
+
+int main(int argc, char** argv)
+{
+  int cpus;
+
+  cpus = get_nprocs();
+  if (cpus <= 1) {
+    printf("We need more than 1 CPU to run this test.  Skipping.\n");
+    return TEST_PASS;
+  }
+  printf("Testing that non-locking writes will corrupt the kvtree file.\n");
+  printf("NOTE: You will see KVTree errors if this is working correctly:\n");
+  printf("Testing with %d CPUs\n", cpus);
+  fflush(stdout);
+
+  if (spawn_processes(0) != 0) {
+    printf("Non-locking test correctly failed\n");
+  } else {
+    printf("Non-locking test should have failed, but didn't\n");
+    return (1);
+  }
+  fflush(stdout);
+
+  printf("Testing that locking writes don't corrupt the kvtree file\n");
+  fflush(stdout);
+  if (spawn_processes(1) == 0) {
+    printf("Locking test correctly passed\n");
+  } else {
+    printf("Locking test failed\n");
+    return (1);
+  }
+
+  return TEST_PASS;
+}


### PR DESCRIPTION
- Add `kvtree_write_with_lock()` for writing a kvfile to a file   safely.
- Add a test case to test file locking
- Use `strtok_r()` in `kvtree_setf()` to make it thread safe.  This prevents errors like:
```
  KVTree 1.0.0 ABORT: Key buffer too small, have 1024 need -1 bytes
```
