### PR TITLE
Add kvtree_read_scatter_single()

### DIFF
--- a/src/kvtree.h
+++ b/src/kvtree.h
@@ -280,6 +280,9 @@ int kvtree_write_close_unlock(const char* file, int* fd, const kvtree* hash);
 int kvtree_write_to_gather(const char* prefix, kvtree* data, int ranks);
 ///@}
 
+/* Read a scatter/gather file and all of its subfiles into a single kvtree */
+int kvtree_read_scatter_single(const char* prefix, kvtree* data);
+
 /********************************************************/
 /** \name Print hash and elements to stdout for debugging */
 ///@{

--- a/src/kvtree_mpi_io.c
+++ b/src/kvtree_mpi_io.c
@@ -131,6 +131,18 @@ static unsigned long kvtree_write_gather_map(
 {
   int rc = KVTREE_SUCCESS;
 
+  if (offset != 0) {
+    /*
+     * While we technically can write to a non-zero offset, there were issues
+     * with doing so with NFS, and so we disable it for now.  It will break
+     * kvtree_read_scatter_single() if we enable it too.
+     */
+    kvtree_abort(1, "Attempt to write a non-zero offset (got %lu) for %s/%s @ %s:%d",
+      offset, prefix, file, __FILE__, __LINE__
+    );
+    return KVTREE_FAILURE;
+  }
+
   /* get name of this process */
   int rank_world, ranks_world;
   MPI_Comm_rank(comm, &rank_world);

--- a/src/kvtree_util.c
+++ b/src/kvtree_util.c
@@ -3,6 +3,7 @@
 #include "kvtree.h"
 #include "kvtree_util.h"
 #include "kvtree_helpers.h"
+#include "kvtree_err.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,11 @@ ADD_TEST(NAME test_kvtree_write_locking COMMAND test_kvtree_write_locking)
 
 IF(MPI_FOUND)
 
+CONFIGURE_FILE(kvtree_read_scatter_single_test.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+ADD_EXECUTABLE(kvtree_read_scatter_single_test kvtree_read_scatter_single_test.c)
+TARGET_LINK_LIBRARIES(kvtree_read_scatter_single_test ${KVTREE_EXTERNAL_LIBS} kvtree)
+KVTREE_ADD_TEST(kvtree_read_scatter_single_test.sh ${CMAKE_CURRENT_SOURCE_DIR}/files "")
+
 ADD_EXECUTABLE(kvtree_bcast_test test_kvtree_bcast.c)
 TARGET_LINK_LIBRARIES(kvtree_bcast_test ${KVTREE_EXTERNAL_LIBS} kvtree)
 KVTREE_ADD_TEST(kvtree_bcast_test 256 "")

--- a/test/kvtree_read_scatter_single_test.c
+++ b/test/kvtree_read_scatter_single_test.c
@@ -1,0 +1,141 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <kvtree.h>
+#include <kvtree_util.h>
+#include <mpi.h>
+#include <limits.h>
+
+/*
+ * Test reading back PREFIX* files into a single kvtree.  This verifies you
+ * can read back a complete PREFIX* set of files.  Also verify that if one
+ * of the PREFIX.*.* files is missing, that the function correctly fails.
+ */
+
+/* Create our PREFIX* files. */
+static int create_files(char *prefix_dir, int ranks)
+{
+  int rc;
+  kvtree* tree = kvtree_new();
+  char name[10];
+  char path[PATH_MAX];
+  int i;
+
+  /* Create a kvtree and stick some data in it */
+  for (i = 0; i < ranks; i++) {
+    sprintf(name, "%d", i);
+    kvtree_util_set_str(tree, name, "test data");
+  }
+
+  snprintf(path, sizeof(path), "%s/PREFIX", prefix_dir);
+  path[sizeof(path) - 1] = '\0';
+  rc = kvtree_write_to_gather(path, tree, ranks);
+  if (rc != KVTREE_SUCCESS) {
+    kvtree_delete(&tree);
+    return rc;
+  }
+
+  /*
+   * Technically your prefix name can have a '.0' in it.  Write some files
+   * like too as a test.  If we're doing everything correctly, the
+   * PREFIX.0.0.x files should not be read in.
+   */
+  snprintf(path, sizeof(path), "%s/PREFIX.0", prefix_dir);
+  path[sizeof(path) - 1] = '\0';
+  rc = kvtree_write_to_gather(path, tree, ranks);
+
+  kvtree_delete(&tree);
+  return rc;
+}
+
+int main(int argc, char** argv)
+{
+  int rc;
+  char tmp[PATH_MAX];
+  char* prefix_dir;
+  char* tmp_str = NULL;
+  char prefix[PATH_MAX];
+  int rank, ranks;
+
+  if (argc != 2) {
+    printf("USAGE:\n");
+    printf("\n");
+    printf("    %s TEMP_DIRECTORY\n", argv[0]);
+    printf("\n");
+    printf("TEMP_DIRECTORY: A temporary directory to store test files in.\n");
+    exit(1);
+  }
+
+  prefix_dir = argv[1];
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+  /* Create our prefix files */
+  rc = create_files(prefix_dir, ranks);
+  if (rc != 0) {
+    printf("Error creating files\n");
+    return 1;
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  /* Only read back the file with rank 0 */
+  if (rank != 0) {
+    rc = 0;
+    goto end;
+  }
+
+  /* Construct path to our main PREFIX file */
+  snprintf(prefix, sizeof(prefix), "%s/PREFIX", prefix_dir);
+  prefix[sizeof(prefix) - 1] = '\0';
+
+  /* Read our PREFIX files */
+  kvtree* kvtree = kvtree_new();
+  rc = kvtree_read_scatter_single(prefix, kvtree);
+  if (rc != KVTREE_SUCCESS) {
+    printf("test_kvtree_read_scatter_single failed for %s\n", prefix);
+    rc = 1;
+    goto end;
+  }
+
+  /* Sanity test a value */
+  kvtree_util_get_str(kvtree, "0", &tmp_str);
+  if (strcmp(tmp_str, "test data") != 0) {
+    printf("Got back wrong data (got %s, expected \"test data\")\n", tmp_str);
+    rc = 1;
+    goto end;
+  }
+  kvtree_print(kvtree, 4);
+  kvtree_delete(&kvtree);
+
+  /*
+   * Remove PREFIX.0.0 to induce a failure.
+   */
+  snprintf(tmp, sizeof(tmp), "%s/PREFIX.0.0", prefix_dir);
+  unlink(tmp);
+
+  /* Attempt to call kvtree_read_scatter_single() - it should fail. */
+  kvtree = kvtree_new();
+  rc = kvtree_read_scatter_single(prefix, kvtree);
+  if (rc == KVTREE_SUCCESS) {
+    printf("kvtree_read_scatter_single() with missing file incorrectly succeeded\n");
+    rc = 1;
+  } else {
+    /* success */
+    rc = 0;
+  }
+
+end:
+  kvtree_delete(&kvtree);
+
+  if (rank == 0) {
+    /* Remove our test files */
+    snprintf(tmp, sizeof(tmp), "rm -f %s/PREFIX*", prefix_dir);
+    system(tmp);
+  }
+  MPI_Finalize();
+
+  return rc;
+}

--- a/test/kvtree_read_scatter_single_test.sh
+++ b/test/kvtree_read_scatter_single_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# We have to run kvtree_read_scatter_single_test from a shell script
+# so that we can set KVTREE_ENTRIES_PER_FILE=1
+KVTREE_ENTRIES_PER_FILE=1 ./kvtree_read_scatter_single_test "${@}"

--- a/test/test_kvtree_write_gather.c
+++ b/test/test_kvtree_write_gather.c
@@ -1,5 +1,6 @@
 #include "test_kvtree.h"
 #include "test_kvtree_util.h"
+#include "kvtree_mpi.h"
 #include <mpi.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Add `kvtree_read_scatter_single()` to read a rank2file and all its subfiles into a single kvtree.  This commit also adds a test case.

`kvtree_read_scatter_single()` is needed by SCR to verify the list of files in the future `scr_poststage` script.