### PR TITLE
fix: always record total ranks in RANKS field in gather/scatter files

### DIFF
--- a/doc/rst/users/gatherscatter.rst
+++ b/doc/rst/users/gatherscatter.rst
@@ -25,8 +25,7 @@ Here are the contents of an example root::
 
 The LEVEL field lists the level at which the current file is located in the tree.
 The leaves of the tree are at level 0.
-The RANKS field specifies the number of ranks the current file
-(and its associated subtree) contains information for.
+The RANKS field specifies the total number of ranks represented by the complete file set.
 
 For levels that are higher than level 0, the RANK kvtree
 contains information about other files to be read.
@@ -63,7 +62,8 @@ Here are the contents of an example file at level 0::
     3
       <kvtree_from_rank_3>
 
-Again, the number of ranks that this file contains information for is recorded under the RANKS field.
+Again, the total number of ranks used to produce the set is recorded in the RANKS field,
+which may be more than the ranks listed in a particular file.
 
 There are entries for specific ranks under the RANK kvtree,
 which is indexed by rank id within MPI_COMM_WORLD.

--- a/src/kvtree.c
+++ b/src/kvtree.c
@@ -1656,7 +1656,7 @@ int kvtree_write_to_gather(const char* prefix, kvtree* data, int ranks)
   /* sort so that elements are ordered by rank value */
   kvtree_sort_int(data, KVTREE_SORT_ASCENDING);
 
-  /* create hash for primary rank2file map and encode level */
+  /* create hash for primary map and encode level */
   kvtree* files_hash = kvtree_new();
   kvtree_set_kv_int(files_hash, "LEVEL", 1);
 
@@ -1668,6 +1668,9 @@ int kvtree_write_to_gather(const char* prefix, kvtree* data, int ranks)
     /* create a hash to record an entry from each rank */
     kvtree* entries = kvtree_new();
     kvtree_set_kv_int(entries, "LEVEL", 0);
+
+    /* record the total number of ranks in each file */
+    kvtree_set_kv_int(entries, "RANKS", ranks);
 
     /* record up to 8K entries */
     int count = 0;
@@ -1691,14 +1694,11 @@ int kvtree_write_to_gather(const char* prefix, kvtree* data, int ranks)
       }
     }
 
-    /* record the number of ranks */
-    kvtree_set_kv_int(entries, "RANKS", count);
-
     /* build name for part file */
     char filename[1024];
     snprintf(filename, sizeof(filename), "%s.0.%d", prefix, writer);
 
-    /* write hash to file rank2file part */
+    /* write hash to file */
     if (kvtree_write_file(filename, entries) != KVTREE_SUCCESS) {
       rc = KVTREE_FAILURE;
       elem = NULL;
@@ -1722,7 +1722,7 @@ int kvtree_write_to_gather(const char* prefix, kvtree* data, int ranks)
   /* record total number of ranks in job as max rank + 1 */
   kvtree_set_kv_int(files_hash, "RANKS", ranks);
 
-  /* write out rank2file map */
+  /* write out root file */
   if (kvtree_write_file(prefix, files_hash) != KVTREE_SUCCESS) {
     rc = KVTREE_FAILURE;
   }


### PR DESCRIPTION
The kvtree gather/scatter files attempted to record the number of ranks in each subtree within the RANKS field.  However, the code was not computing this value correctly.  Since this field is not really used, replace this value with the total number of ranks instead.