### PR TITLE
Fix minor build warning

### DIFF
--- a/test/test_kvtree_write_gather.c
+++ b/test/test_kvtree_write_gather.c
@@ -1,5 +1,6 @@
 #include "test_kvtree.h"
 #include "test_kvtree_util.h"
+#include "kvtree_mpi.h"
 #include <mpi.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Fix:

 `test_kvtree_write_gather.c warning: implicit declaration of function ‘kvtree_write_gather`