### PR TITLE
add cmake option to compile tv_data_display.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Configuration Options
 OPTION(MPI "Enable MPI operations for kvtrees" ON)
 OPTION(KVTREE_LINK_STATIC "Default to static linking? (Needed for Cray)" OFF)
+OPTION(TVDISPLAY "Whether to compile tv_data_display.c for debugging with TotalView C++View" OFF)
 
 SET(KVTREE_FILE_LOCK "FLOCK" CACHE STRING "Specify type of file locking to use (FLOCK FCNTL NONE)")
 SET_PROPERTY(CACHE KVTREE_FILE_LOCK PROPERTY STRINGS FLOCK FCNTL NONE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,10 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 # LIB KVTREE #
 ###########
 
+IF(TVDISPLAY)
+    ADD_DEFINITIONS(-DHAVE_TV)
+ENDIF(TVDISPLAY)
+
 # Install header files
 LIST(APPEND libkvtree_install_headers
     kvtree.h
@@ -21,8 +25,11 @@ LIST(APPEND libkvtree_noMPI_srcs
     kvtree_io.c
     kvtree_helpers.c
     kvtree_err.c
-    tv_data_display.c
 )
+
+IF(TVDISPLAY)
+    LIST(APPEND libkvtree_noMPI_srcs tv_data_display.c)
+ENDIF(TVDISPLAY)
 
 LIST(APPEND libkvtree_srcs
     kvtree.c
@@ -30,8 +37,11 @@ LIST(APPEND libkvtree_srcs
     kvtree_io.c
     kvtree_helpers.c
     kvtree_err.c
-    tv_data_display.c
 )
+
+IF(TVDISPLAY)
+    LIST(APPEND libkvtree_srcs tv_data_display.c)
+ENDIF(TVDISPLAY)
 
 IF(MPI_FOUND)
     LIST(APPEND libkvtree_srcs kvtree_mpi.c kvtree_mpi_io.c)


### PR DESCRIPTION
Only compile tv_data_display.c as part of libkvtree when given a cmake option of ``-DTVDISPLAY=ON``, see https://github.com/LLNL/scr/issues/290