### PR TITLE
Bugfix: read scatter single test multiple ranks

### DIFF
--- a/test/kvtree_read_scatter_single_test.c
+++ b/test/kvtree_read_scatter_single_test.c
@@ -56,6 +56,7 @@ int main(int argc, char** argv)
   char* tmp_str = NULL;
   char prefix[PATH_MAX];
   int rank, ranks;
+  kvtree* kvtree = NULL;
 
   if (argc != 2) {
     printf("USAGE:\n");
@@ -92,7 +93,7 @@ int main(int argc, char** argv)
   prefix[sizeof(prefix) - 1] = '\0';
 
   /* Read our PREFIX files */
-  kvtree* kvtree = kvtree_new();
+  kvtree = kvtree_new();
   rc = kvtree_read_scatter_single(prefix, kvtree);
   if (rc != KVTREE_SUCCESS) {
     printf("test_kvtree_read_scatter_single failed for %s\n", prefix);


### PR DESCRIPTION
The _kvtree_read_scatter_single_test_ is failing for me on Lassen when using more than one rank. It looks like the non-zero ranks are calling `kvtree_delete()` without ever calling `kvtree_new()`.

It seems in some setups `&kvtree` shows as a pointer to an error (`kvtree: 0x7fffffff9d00 -> $error`) rather than `NULL` when it was never created. 

In Totalview, when `kvtree_delete()` is then called, `ptr_hash` looks like:
```
ptr_hash:                     0x7fffffff9cd0 -> 0x7fffffff9d00 -> $error
``` 
https://github.com/ECP-VeloC/KVTree/blob/49f885e90f6a7a222c727ef05c8d9468f2fc5695/src/kvtree.c#L77-L82

allowing the checks for `NULL` to pass, the `while` loop being entered, and a delete attempted.
This results in a segfault.

This changes _kvtree_read_scatter_single_test.c_ to initialize kvtree to NULL to allow ranks that never create kvtree to call `kvtree_delete()`.
The test started passing for me with this change.