### PR TITLE
Incremental release v1.1.1

### DIFF
--- a/src/kvtree.h
+++ b/src/kvtree.h
@@ -63,9 +63,9 @@ extern "C" {
  * and a pointer to another hash.
  */
 #define KVTREE_MAJOR "1"
-#define KVTREE_MINOR "0"
-#define KVTREE_PATCH "0"
-#define KVTREE_VERSION "1.0.0"
+#define KVTREE_MINOR "1"
+#define KVTREE_PATCH "1"
+#define KVTREE_VERSION "1.1.1"
 #define KVTREE_SUCCESS (0)
 #define KVTREE_MAX_FILENAME (1024)
 


### PR DESCRIPTION
Update KVTREE_VERSION to v1.1.1 for tagging release.

This is in preparation for SCR 3.0 release and addresses the second item of #49

@gonsie, this also updates the corresponding KVTREE_MINOR and KVTREE_PATCH numbers. It doesn't look like any of the other components have these values. Do we want to add them to the others at some point? Or I can remove them from this component if we don't want to continue maintaining them?