### PR TITLE
Intremental release v1.2.0

### DIFF
--- a/src/kvtree.h
+++ b/src/kvtree.h
@@ -62,10 +62,7 @@ extern "C" {
  * where each element contains a key (char string)
  * and a pointer to another hash.
  */
-#define KVTREE_MAJOR "1"
-#define KVTREE_MINOR "1"
-#define KVTREE_PATCH "1"
-#define KVTREE_VERSION "1.1.1"
+#define KVTREE_VERSION "1.2.0"
 #define KVTREE_SUCCESS (0)
 #define KVTREE_MAX_FILENAME (1024)
 


### PR DESCRIPTION
Update `KVTREE_VERSION` to v1.2.0 for tagging a new release in preparation for SCR v3.0rc2.

Removes the unused `KVTREE_MAJOR`, `KVTREE_MINOR`, and `KVTREE_PATCH` definitions.

Addresses item three of #57