### PR TITLE
refactored cmake actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,8 +16,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         target: [Debug, Release]
         mpi: [seq, par]
+        static: [both, static]
 
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}-${{ matrix.static }}
 
     runs-on: ${{ matrix.os }}
 
@@ -35,16 +36,20 @@ jobs:
           os: ${{ matrix.os }}
           mpi: ${{ matrix.mpi }}
 
-      - name: build static
-        uses: ecp-veloc/github-actions/cmake-build-static@main
+      - name: configure
+        uses: ecp-veloc/github-actions/cmake-configure@main
         with:
           component: kvtree
           target: ${{ matrix.target }}
           cmake_line: "-DMPI=${{ matrix.mpi == 'par' }}"
+          static: ${{ matrix.static == 'static' }}
 
-      - name: build and test
-        uses: ecp-veloc/github-actions/cmake-build-test@main
+      - name: build
+        uses: ecp-veloc/github-actions/cmake-build@main
         with:
           component: kvtree
-          target: ${{ matrix.target }}
-          cmake_line: "-DMPI=${{ matrix.mpi == 'par' }}"
+
+      - name: test
+        uses: ecp-veloc/github-actions/cmake-test@main
+        with:
+          component: kvtree


### PR DESCRIPTION
With ecp-veloc/github-actions@dbb637ff9ed1d7de47fe85c66f990488769b9573 the cmake actions have been refactored to support a static-only build.